### PR TITLE
1078 SDK upgrade strategy, with legacy refresh.

### DIFF
--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPITests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPITests.swift
@@ -38,3 +38,51 @@ final class SchibstedAccountAPITests: XCTestCase {
         }
     }
 }
+
+final class RequestBuilderTests: XCTestCase {
+    
+    // MARK: CodeExchange tests
+
+    func testCodeExchangeAsRequestExpectedURL() throws {
+        let expectedClientId = "aString"
+        let baseURL = URL("https://example.com")
+        let expectedURL = baseURL.appendingPathComponent("/api/2/oauth/exchange")
+        
+        let sut = RequestBuilder.codeExchange(clientId: expectedClientId)
+        let request = sut.asRequest(baseURL: baseURL)
+        XCTAssertEqual(request.url, expectedURL)
+    }
+    
+    func testCodeExchangeAsRequestWrongURL() throws {
+        let expectedClientId = "aString"
+        let baseURL = URL("https://example.com")
+        let expectedURL = baseURL.appendingPathComponent("/bad/path")
+        
+        let sut = RequestBuilder.codeExchange(clientId: expectedClientId)
+        let request = sut.asRequest(baseURL: baseURL)
+        XCTAssertNotEqual(request.url, expectedURL)
+    }
+    
+    // MARK: OldSDKRefreshToken tests
+    
+    func testOldSDKRefreshTokenAsRequestExpectedURL() throws {
+        let baseURL = URL("https://example.com")
+        let expectedURL = baseURL.appendingPathComponent("/oauth/token")
+        let expectedRefreshToken = "A refreshToken"
+        
+        let sut = RequestBuilder.oldSDKRefreshToken(oldSDKRefreshToken: expectedRefreshToken)
+        let request = sut.asRequest(baseURL: baseURL)
+        XCTAssertEqual(request.url, expectedURL, "The url expected path should be: \(expectedURL.absoluteString)")
+    }
+    
+    func testOldSDKRefreshTokenAsRequestWrongURL() throws {
+        let baseURL = URL("https://example.com")
+        let expectedURL = baseURL.appendingPathComponent("/bad/path")
+        let expectedRefreshToken = "A refreshToken"
+        
+        let sut = RequestBuilder.oldSDKRefreshToken(oldSDKRefreshToken: expectedRefreshToken)
+        let request = sut.asRequest(baseURL: baseURL)
+        XCTAssertNotEqual(request.url, expectedURL, "The url expected path should be: /oauth/token")
+    }
+    
+}

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPITests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/API/SchibstedAccountAPITests.swift
@@ -91,8 +91,6 @@ final class SchibstedAccountAPITests: XCTestCase {
         }
     }
     
-  
-    
     func testOldSDKRefreshSuccessResponse() {
         let expectedResponse = TokenResponse(access_token: Fixtures.userTokens.accessToken,
                                              refresh_token: Fixtures.userTokens.refreshToken,

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/GeneratedMocks.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/GeneratedMocks.swift
@@ -1,4 +1,254 @@
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/HTTP/HTTPClient.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPI.swift at 2021-09-29 13:57:12 +0000
+
+
+import Cuckoo
+@testable import AccountSDKIOSWeb
+
+import Foundation
+import UIKit
+
+
+ class MockSchibstedAccountAPI: SchibstedAccountAPI, Cuckoo.ClassMock {
+    
+     typealias MocksType = SchibstedAccountAPI
+    
+     typealias Stubbing = __StubbingProxy_SchibstedAccountAPI
+     typealias Verification = __VerificationProxy_SchibstedAccountAPI
+
+     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
+
+    
+    private var __defaultImplStub: SchibstedAccountAPI?
+
+     func enableDefaultImplementation(_ stub: SchibstedAccountAPI) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+    
+
+    
+
+    
+
+    
+    
+    
+     override func sessionExchange(for user: User, clientId: String, redirectURI: String, completion: @escaping HTTPResultHandler<SessionExchangeResponse>)  {
+        
+    return cuckoo_manager.call("sessionExchange(for: User, clientId: String, redirectURI: String, completion: @escaping HTTPResultHandler<SessionExchangeResponse>)",
+            parameters: (user, clientId, redirectURI, completion),
+            escapingParameters: (user, clientId, redirectURI, completion),
+            superclassCall:
+                
+                super.sessionExchange(for: user, clientId: clientId, redirectURI: redirectURI, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.sessionExchange(for: user, clientId: clientId, redirectURI: redirectURI, completion: completion))
+        
+    }
+    
+    
+    
+     override func codeExchange(for user: User, clientId: String, completion: @escaping HTTPResultHandler<CodeExchangeResponse>)  {
+        
+    return cuckoo_manager.call("codeExchange(for: User, clientId: String, completion: @escaping HTTPResultHandler<CodeExchangeResponse>)",
+            parameters: (user, clientId, completion),
+            escapingParameters: (user, clientId, completion),
+            superclassCall:
+                
+                super.codeExchange(for: user, clientId: clientId, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.codeExchange(for: user, clientId: clientId, completion: completion))
+        
+    }
+    
+    
+    
+     override func tokenRequest(with httpClient: HTTPClient, parameters: [String: String], completion: @escaping HTTPResultHandler<TokenResponse>)  {
+        
+    return cuckoo_manager.call("tokenRequest(with: HTTPClient, parameters: [String: String], completion: @escaping HTTPResultHandler<TokenResponse>)",
+            parameters: (httpClient, parameters, completion),
+            escapingParameters: (httpClient, parameters, completion),
+            superclassCall:
+                
+                super.tokenRequest(with: httpClient, parameters: parameters, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.tokenRequest(with: httpClient, parameters: parameters, completion: completion))
+        
+    }
+    
+    
+    
+     override func userProfile(for user: User, completion: @escaping HTTPResultHandler<UserProfileResponse>)  {
+        
+    return cuckoo_manager.call("userProfile(for: User, completion: @escaping HTTPResultHandler<UserProfileResponse>)",
+            parameters: (user, completion),
+            escapingParameters: (user, completion),
+            superclassCall:
+                
+                super.userProfile(for: user, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.userProfile(for: user, completion: completion))
+        
+    }
+    
+    
+    
+     override func oldSDKCodeExchange(with httpClient: HTTPClient, clientId: String, oldSDKAccessToken: String, completion: @escaping HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)  {
+        
+    return cuckoo_manager.call("oldSDKCodeExchange(with: HTTPClient, clientId: String, oldSDKAccessToken: String, completion: @escaping HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)",
+            parameters: (httpClient, clientId, oldSDKAccessToken, completion),
+            escapingParameters: (httpClient, clientId, oldSDKAccessToken, completion),
+            superclassCall:
+                
+                super.oldSDKCodeExchange(with: httpClient, clientId: clientId, oldSDKAccessToken: oldSDKAccessToken, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.oldSDKCodeExchange(with: httpClient, clientId: clientId, oldSDKAccessToken: oldSDKAccessToken, completion: completion))
+        
+    }
+    
+    
+    
+     override func oldSDKRefresh(with httpClient: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse>)  {
+        
+    return cuckoo_manager.call("oldSDKRefresh(with: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse>)",
+            parameters: (httpClient, refreshToken, clientId, clientSecret, completion),
+            escapingParameters: (httpClient, refreshToken, clientId, clientSecret, completion),
+            superclassCall:
+                
+                super.oldSDKRefresh(with: httpClient, refreshToken: refreshToken, clientId: clientId, clientSecret: clientSecret, completion: completion)
+                ,
+            defaultCall: __defaultImplStub!.oldSDKRefresh(with: httpClient, refreshToken: refreshToken, clientId: clientId, clientSecret: clientSecret, completion: completion))
+        
+    }
+    
+
+	 struct __StubbingProxy_SchibstedAccountAPI: Cuckoo.StubbingProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	
+	     init(manager: Cuckoo.MockManager) {
+	        self.cuckoo_manager = manager
+	    }
+	    
+	    
+	    func sessionExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable>(for user: M1, clientId: M2, redirectURI: M3, completion: M4) -> Cuckoo.ClassStubNoReturnFunction<(User, String, String, HTTPResultHandler<SessionExchangeResponse>)> where M1.MatchedType == User, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == HTTPResultHandler<SessionExchangeResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, String, String, HTTPResultHandler<SessionExchangeResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: redirectURI) { $0.2 }, wrap(matchable: completion) { $0.3 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "sessionExchange(for: User, clientId: String, redirectURI: String, completion: @escaping HTTPResultHandler<SessionExchangeResponse>)", parameterMatchers: matchers))
+	    }
+	    
+	    func codeExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(for user: M1, clientId: M2, completion: M3) -> Cuckoo.ClassStubNoReturnFunction<(User, String, HTTPResultHandler<CodeExchangeResponse>)> where M1.MatchedType == User, M2.MatchedType == String, M3.MatchedType == HTTPResultHandler<CodeExchangeResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, String, HTTPResultHandler<CodeExchangeResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "codeExchange(for: User, clientId: String, completion: @escaping HTTPResultHandler<CodeExchangeResponse>)", parameterMatchers: matchers))
+	    }
+	    
+	    func tokenRequest<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(with httpClient: M1, parameters: M2, completion: M3) -> Cuckoo.ClassStubNoReturnFunction<(HTTPClient, [String: String], HTTPResultHandler<TokenResponse>)> where M1.MatchedType == HTTPClient, M2.MatchedType == [String: String], M3.MatchedType == HTTPResultHandler<TokenResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, [String: String], HTTPResultHandler<TokenResponse>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: parameters) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "tokenRequest(with: HTTPClient, parameters: [String: String], completion: @escaping HTTPResultHandler<TokenResponse>)", parameterMatchers: matchers))
+	    }
+	    
+	    func userProfile<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(for user: M1, completion: M2) -> Cuckoo.ClassStubNoReturnFunction<(User, HTTPResultHandler<UserProfileResponse>)> where M1.MatchedType == User, M2.MatchedType == HTTPResultHandler<UserProfileResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, HTTPResultHandler<UserProfileResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: completion) { $0.1 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "userProfile(for: User, completion: @escaping HTTPResultHandler<UserProfileResponse>)", parameterMatchers: matchers))
+	    }
+	    
+	    func oldSDKCodeExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable>(with httpClient: M1, clientId: M2, oldSDKAccessToken: M3, completion: M4) -> Cuckoo.ClassStubNoReturnFunction<(HTTPClient, String, String, HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)> where M1.MatchedType == HTTPClient, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, String, String, HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: oldSDKAccessToken) { $0.2 }, wrap(matchable: completion) { $0.3 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "oldSDKCodeExchange(with: HTTPClient, clientId: String, oldSDKAccessToken: String, completion: @escaping HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)", parameterMatchers: matchers))
+	    }
+	    
+	    func oldSDKRefresh<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable, M5: Cuckoo.Matchable>(with httpClient: M1, refreshToken: M2, clientId: M3, clientSecret: M4, completion: M5) -> Cuckoo.ClassStubNoReturnFunction<(HTTPClient, String, String, String, HTTPResultHandler<TokenResponse>)> where M1.MatchedType == HTTPClient, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == String, M5.MatchedType == HTTPResultHandler<TokenResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, String, String, String, HTTPResultHandler<TokenResponse>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: refreshToken) { $0.1 }, wrap(matchable: clientId) { $0.2 }, wrap(matchable: clientSecret) { $0.3 }, wrap(matchable: completion) { $0.4 }]
+	        return .init(stub: cuckoo_manager.createStub(for: MockSchibstedAccountAPI.self, method: "oldSDKRefresh(with: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse>)", parameterMatchers: matchers))
+	    }
+	    
+	}
+
+	 struct __VerificationProxy_SchibstedAccountAPI: Cuckoo.VerificationProxy {
+	    private let cuckoo_manager: Cuckoo.MockManager
+	    private let callMatcher: Cuckoo.CallMatcher
+	    private let sourceLocation: Cuckoo.SourceLocation
+	
+	     init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+	        self.cuckoo_manager = manager
+	        self.callMatcher = callMatcher
+	        self.sourceLocation = sourceLocation
+	    }
+	
+	    
+	
+	    
+	    @discardableResult
+	    func sessionExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable>(for user: M1, clientId: M2, redirectURI: M3, completion: M4) -> Cuckoo.__DoNotUse<(User, String, String, HTTPResultHandler<SessionExchangeResponse>), Void> where M1.MatchedType == User, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == HTTPResultHandler<SessionExchangeResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, String, String, HTTPResultHandler<SessionExchangeResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: redirectURI) { $0.2 }, wrap(matchable: completion) { $0.3 }]
+	        return cuckoo_manager.verify("sessionExchange(for: User, clientId: String, redirectURI: String, completion: @escaping HTTPResultHandler<SessionExchangeResponse>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func codeExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(for user: M1, clientId: M2, completion: M3) -> Cuckoo.__DoNotUse<(User, String, HTTPResultHandler<CodeExchangeResponse>), Void> where M1.MatchedType == User, M2.MatchedType == String, M3.MatchedType == HTTPResultHandler<CodeExchangeResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, String, HTTPResultHandler<CodeExchangeResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+	        return cuckoo_manager.verify("codeExchange(for: User, clientId: String, completion: @escaping HTTPResultHandler<CodeExchangeResponse>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func tokenRequest<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(with httpClient: M1, parameters: M2, completion: M3) -> Cuckoo.__DoNotUse<(HTTPClient, [String: String], HTTPResultHandler<TokenResponse>), Void> where M1.MatchedType == HTTPClient, M2.MatchedType == [String: String], M3.MatchedType == HTTPResultHandler<TokenResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, [String: String], HTTPResultHandler<TokenResponse>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: parameters) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+	        return cuckoo_manager.verify("tokenRequest(with: HTTPClient, parameters: [String: String], completion: @escaping HTTPResultHandler<TokenResponse>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func userProfile<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(for user: M1, completion: M2) -> Cuckoo.__DoNotUse<(User, HTTPResultHandler<UserProfileResponse>), Void> where M1.MatchedType == User, M2.MatchedType == HTTPResultHandler<UserProfileResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(User, HTTPResultHandler<UserProfileResponse>)>] = [wrap(matchable: user) { $0.0 }, wrap(matchable: completion) { $0.1 }]
+	        return cuckoo_manager.verify("userProfile(for: User, completion: @escaping HTTPResultHandler<UserProfileResponse>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func oldSDKCodeExchange<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable>(with httpClient: M1, clientId: M2, oldSDKAccessToken: M3, completion: M4) -> Cuckoo.__DoNotUse<(HTTPClient, String, String, HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>), Void> where M1.MatchedType == HTTPClient, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, String, String, HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: clientId) { $0.1 }, wrap(matchable: oldSDKAccessToken) { $0.2 }, wrap(matchable: completion) { $0.3 }]
+	        return cuckoo_manager.verify("oldSDKCodeExchange(with: HTTPClient, clientId: String, oldSDKAccessToken: String, completion: @escaping HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	    @discardableResult
+	    func oldSDKRefresh<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable, M4: Cuckoo.Matchable, M5: Cuckoo.Matchable>(with httpClient: M1, refreshToken: M2, clientId: M3, clientSecret: M4, completion: M5) -> Cuckoo.__DoNotUse<(HTTPClient, String, String, String, HTTPResultHandler<TokenResponse>), Void> where M1.MatchedType == HTTPClient, M2.MatchedType == String, M3.MatchedType == String, M4.MatchedType == String, M5.MatchedType == HTTPResultHandler<TokenResponse> {
+	        let matchers: [Cuckoo.ParameterMatcher<(HTTPClient, String, String, String, HTTPResultHandler<TokenResponse>)>] = [wrap(matchable: httpClient) { $0.0 }, wrap(matchable: refreshToken) { $0.1 }, wrap(matchable: clientId) { $0.2 }, wrap(matchable: clientSecret) { $0.3 }, wrap(matchable: completion) { $0.4 }]
+	        return cuckoo_manager.verify("oldSDKRefresh(with: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse>)", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+	    }
+	    
+	}
+}
+
+ class SchibstedAccountAPIStub: SchibstedAccountAPI {
+    
+
+    
+
+    
+     override func sessionExchange(for user: User, clientId: String, redirectURI: String, completion: @escaping HTTPResultHandler<SessionExchangeResponse>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     override func codeExchange(for user: User, clientId: String, completion: @escaping HTTPResultHandler<CodeExchangeResponse>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     override func tokenRequest(with httpClient: HTTPClient, parameters: [String: String], completion: @escaping HTTPResultHandler<TokenResponse>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     override func userProfile(for user: User, completion: @escaping HTTPResultHandler<UserProfileResponse>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     override func oldSDKCodeExchange(with httpClient: HTTPClient, clientId: String, oldSDKAccessToken: String, completion: @escaping HTTPResultHandler<SchibstedAccountAPIResponse<CodeExchangeResponse>>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+     override func oldSDKRefresh(with httpClient: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse>)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+}
+
+
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/HTTP/HTTPClient.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -97,7 +347,7 @@ public class HTTPClientStub: HTTPClient {
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/HTTP/URLSessionProtocol.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/HTTP/URLSessionProtocol.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -196,7 +446,7 @@ import Foundation
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainSessionStorage.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainSessionStorage.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -326,7 +576,7 @@ import JOSESwift
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainTokenStorage.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainTokenStorage.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -455,7 +705,7 @@ import Foundation
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/KeychainSessionStorage.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/KeychainSessionStorage.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -644,7 +894,7 @@ import Foundation
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/SessionStorage.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/SessionStorage.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo
@@ -834,7 +1084,7 @@ import Security
 }
 
 
-// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Storage.swift at 2021-07-16 13:47:30 +0000
+// MARK: - Mocks generated from file: ../../Sources/AccountSDKIOSWeb/Lib/Storage/Storage.swift at 2021-09-29 13:57:12 +0000
 
 
 import Cuckoo

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
@@ -149,3 +149,159 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         verify(legacyStorage).get(forClientId: clientId)
     }
 }
+
+final class OldSDKClientTests: XCTestCase {
+    
+    func testOneTimeCodeWithRefreshOnCodeExchangeFailure401() throws {
+        let expectedCode = "A code string"
+        let expectedResponse = SchibstedAccountAPIResponse(data: CodeExchangeResponse(code: expectedCode))
+        let mockHTTPClient = MockHTTPClient()
+        stub(mockHTTPClient) {mock in
+            when(mock.execute(request: any(), withRetryPolicy: any(), completion: anyClosure()))
+                .then { _, _, completion in
+                    completion(.success(expectedResponse))
+                }
+        }
+        
+        let expectedTokenRefreshResponse = TokenResponse(access_token: Fixtures.userTokens.accessToken,
+                                             refresh_token: nil,
+                                             id_token: nil,
+                                             scope: nil,
+                                             expires_in: 1337)
+        let mockApi = MockSchibstedAccountAPI(baseURL: Fixtures.clientConfig.serverURL)
+        var codeExchangeCallCount = 0
+        stub(mockApi) { mock in
+            when(mock.oldSDKCodeExchange(with: any(), clientId: any(), oldSDKAccessToken: any(), completion: anyClosure()))
+                .then{ _, _, _, completion in
+                    codeExchangeCallCount += 1
+                    completion(.failure(HTTPError.errorResponse(code: 401, body: nil)))
+                }
+            when(mock.oldSDKRefresh(with: any(), refreshToken: any(), clientId: any(), clientSecret: any(), completion: anyClosure()))
+                .then { _, _, _, _, completion in
+                    completion(.success(expectedTokenRefreshResponse))
+                }
+        }
+        
+        
+        let sut = OldSDKClient(clientId: "", clientSecret: "", api: mockApi, legacyTokens: Fixtures.userTokens, httpClient: mockHTTPClient)
+        Await.until { done in
+            sut.oneTimeCodeWithOldSDKRefresh(newSDKClientId: "") { result in
+                switch result {
+                case .failure(.errorResponse(let errorCode, _)):
+                    XCTAssertEqual(codeExchangeCallCount, 2, "Code Exchange should only be called 2 times on 401 failure.")
+                    XCTAssertEqual(401, errorCode)
+                default:
+                    XCTFail("Unexpected result \(result)")
+                }
+                
+                done()
+            }
+        }
+    }
+    
+    func testOneTimeCodeWithRefreshOnCodeExchangeSuccess() throws {
+        let expectedCode = "A code string"
+        let expectedResponse = SchibstedAccountAPIResponse(data: CodeExchangeResponse(code: expectedCode))
+        let mockHTTPClient = MockHTTPClient()
+        stub(mockHTTPClient) {mock in
+            when(mock.execute(request: any(), withRetryPolicy: any(), completion: anyClosure()))
+                .then { _, _, completion in
+                    completion(.success(expectedResponse))
+                }
+        }
+        
+        let expectedTokenRefreshResponse = TokenResponse(access_token: Fixtures.userTokens.accessToken,
+                                             refresh_token: nil,
+                                             id_token: nil,
+                                             scope: nil,
+                                             expires_in: 1337)
+        let mockApi = MockSchibstedAccountAPI(baseURL: Fixtures.clientConfig.serverURL)
+        var codeExchangeCallCount = 0
+        stub(mockApi) { mock in
+            when(mock.oldSDKCodeExchange(with: any(), clientId: any(), oldSDKAccessToken: any(), completion: anyClosure()))
+                .then{ _, _, _, completion in
+                    codeExchangeCallCount += 1
+                    completion(.success(expectedResponse))
+                }
+            when(mock.oldSDKRefresh(with: any(), refreshToken: any(), clientId: any(), clientSecret: any(), completion: anyClosure()))
+                .then { _, _, _, _, completion in
+                    completion(.success(expectedTokenRefreshResponse))
+                }
+        }
+        
+        
+        let sut = OldSDKClient(clientId: "", clientSecret: "", api: mockApi, legacyTokens: Fixtures.userTokens, httpClient: mockHTTPClient)
+        Await.until { done in
+            sut.oneTimeCodeWithOldSDKRefresh(newSDKClientId: "") { result in
+                switch result {
+                case .success(let code):
+                    XCTAssertEqual(codeExchangeCallCount, 1, "Code Exchange should only be called once.")
+                    XCTAssertEqual(expectedCode, code)
+                default:
+                    XCTFail("Unexpected result \(result)")
+                }
+                
+                done()
+            }
+        }
+    }
+    
+    func testOLDSDKRefresh() throws {
+        let expectedResponse = TokenResponse(access_token: Fixtures.userTokens.accessToken,
+                                             refresh_token: nil,
+                                             id_token: nil,
+                                             scope: nil,
+                                             expires_in: 1337)
+        
+        let mockHTTPClient = MockHTTPClient()
+        stub(mockHTTPClient) {mock in
+            when(mock.execute(request: any(), withRetryPolicy: any(), completion: anyClosure()))
+                .then { _, _, completion in
+                    completion(.success(expectedResponse))
+                }
+        }
+        
+        let api = SchibstedAccountAPI(baseURL: Fixtures.clientConfig.serverURL)
+        let sut = OldSDKClient(clientId: "", clientSecret: "", api: api, legacyTokens: Fixtures.userTokens, httpClient: mockHTTPClient)
+        
+        Await.until { done in
+            sut.oldSDKRefresh(refreshToken: "") { result in
+                switch result {
+                case .success(let refreshedToken):
+                    XCTAssertEqual(refreshedToken, Fixtures.userTokens.accessToken)
+                default:
+                    XCTFail("Unexpected result \(result)")
+                }
+                done()
+            }
+        }
+    }
+    
+    func testOneTimeCode() throws {
+        let expectedCode = "A code string"
+        let expectedResponse = SchibstedAccountAPIResponse(data: CodeExchangeResponse(code: expectedCode))
+
+        let mockHTTPClient = MockHTTPClient()
+        stub(mockHTTPClient) {mock in
+            when(mock.execute(request: any(), withRetryPolicy: any(), completion: anyClosure()))
+                .then { _, _, completion in
+                    completion(.success(expectedResponse))
+                }
+        }
+        
+        let api = SchibstedAccountAPI(baseURL: Fixtures.clientConfig.serverURL)
+        let sut = OldSDKClient(clientId: "", clientSecret: "", api: api, legacyTokens: Fixtures.userTokens, httpClient: mockHTTPClient)
+        
+        Await.until { done in
+            sut.oneTimeCode(newSDKClientId: "", oldSDKAccessToken: "") { result in
+                switch result {
+                case .success(let code):
+                    XCTAssertEqual(code, expectedCode)
+                default:
+                    XCTFail("Unexpected result \(result)")
+                }
+                done()
+            }
+        }
+    }
+}

--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
@@ -15,6 +15,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage,
                                                               to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.store(userSession)
 
@@ -34,6 +35,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage,
                                                               to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.getAll()
 
@@ -52,6 +54,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.remove(forClientId: clientId)
 
@@ -75,6 +78,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in
@@ -105,6 +109,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in
@@ -133,6 +138,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in

--- a/Projects/AccountSDKIOSWeb/generate_mocks.sh
+++ b/Projects/AccountSDKIOSWeb/generate_mocks.sh
@@ -6,4 +6,5 @@
     ../../Sources/AccountSDKIOSWeb/Lib/Storage/Storage.swift \
     ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainSessionStorage.swift \
     ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/LegacyKeychainTokenStorage.swift \
+    ../../Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPI.swift \
     ../../Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/KeychainSessionStorage.swift

--- a/Sources/AccountSDKIOSWeb/Client/Client.swift
+++ b/Sources/AccountSDKIOSWeb/Client/Client.swift
@@ -5,13 +5,15 @@ public typealias LoginResultHandler = (Result<User, LoginError>) -> Void
 
 public struct SessionStorageConfig {
     let legacyClientId: String
+    let legacyClientSecret: String
     let accessGroup: String?
     let legacyAccessGroup: String?
     
-    public init(legacyClientID: String, accessGroup: String? = nil, legacyAccessGroup: String? = nil) {
+    public init(legacyClientID: String, legacyClientSecret: String, accessGroup: String? = nil, legacyAccessGroup: String? = nil) {
         self.legacyClientId = legacyClientID
         self.accessGroup = accessGroup
         self.legacyAccessGroup = legacyAccessGroup
+        self.legacyClientSecret = legacyClientSecret
     }
 }
 
@@ -74,6 +76,7 @@ public class Client: CustomStringConvertible {
         let sessionStorage = MigratingKeychainCompatStorage(from: legacySessionStorage,
                                                             to: newSessionStorage,
                                                             legacyClient: legacyClient,
+                                                            legacyClientSecret: sessionStorageConfig.legacyClientSecret,
                                                             makeTokenRequest: { authCode, authState, completion in tokenHandler.makeTokenRequest(authCode: authCode, authState: authState, completion: completion)})
         
         self.init(configuration: configuration,

--- a/Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPI.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/API/SchibstedAccountAPI.swift
@@ -148,8 +148,8 @@ class SchibstedAccountAPI {
     /// API endpoint called with old SDK clientID and old SDK Client secret, and old SDK refreshToken
     func oldSDKRefresh(with httpClient: HTTPClient, refreshToken: String, clientId: String, clientSecret: String, completion: @escaping HTTPResultHandler<TokenResponse> ) {
         let request = RequestBuilder.oldSDKRefreshToken(oldSDKRefreshToken: refreshToken).asRequest(baseURL: baseURL)
-        let authenticatedBasicRequest = authenticatedBasicRequest(request, legacyClientId: clientId, legacyClientSecret: clientSecret)
-        httpClient.execute(request: SchibstedAccountAPI.addingSDKHeaders(to: authenticatedBasicRequest),
+        let authenticatedRequest = authenticatedBasicRequest(request, legacyClientId: clientId, legacyClientSecret: clientSecret)
+        httpClient.execute(request: SchibstedAccountAPI.addingSDKHeaders(to: authenticatedRequest),
                            withRetryPolicy: retryPolicy,
                            completion: completion)
     }

--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
@@ -6,6 +6,7 @@ class MigratingKeychainCompatStorage: SessionStorage {
     private let legacyClient: Client
     private let legacyClientSecret: String
     private let makeTokenRequest: (_ authCode: String, _ authState: AuthState?, _ completion:  @escaping (Result<TokenResult, TokenError>) -> Void) -> Void
+    private var oldSDKClient: OldSDKClient?
     
     init(from: LegacyKeychainSessionStorage,
          to: KeychainSessionStorage,
@@ -44,9 +45,9 @@ class MigratingKeychainCompatStorage: SessionStorage {
     }
     
     private func migrateLegacyUserSession(forClientId: String, legacySession: UserSession, completion: @escaping (UserSession?) -> Void) {
-        let legacyUser = User(client: legacyClient, tokens: legacySession.userTokens)
         
-        legacyUser.oneTimeCode(clientId: forClientId) { result in
+        self.oldSDKClient = OldSDKClient(clientId: legacyClient.configuration.clientId, clientSecret: self.legacyClientSecret, api: legacyClient.schibstedAccountAPI, legacyTokens: legacySession.userTokens)
+        oldSDKClient?.oneTimeCodeWithOldSDKRefresh(newSDKClientId: forClientId) { result in
             switch result {
             case .success(let code):
                 self.makeTokenRequest(code, nil) { result in
@@ -79,3 +80,83 @@ class MigratingKeychainCompatStorage: SessionStorage {
     }
 }
 
+///  OldSDKClient is responsible for exchanging Old SDK Token to an Authorization code.
+class OldSDKClient {
+    let clientId: String
+    let clientSecret: String
+    let api: SchibstedAccountAPI
+    let legacyTokens: UserTokens
+    var httpClient: HTTPClient
+    
+    init(clientId: String, clientSecret: String, api: SchibstedAccountAPI, legacyTokens: UserTokens, httpClient: HTTPClient) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.api = api
+        self.legacyTokens = legacyTokens
+        self.httpClient = httpClient
+        
+    }
+    
+    convenience init(clientId: String, clientSecret: String, api: SchibstedAccountAPI, legacyTokens: UserTokens) {
+        let httpClient = HTTPClientWithURLSession()
+        self.init(clientId: clientId, clientSecret: clientSecret, api: api, legacyTokens: legacyTokens, httpClient: httpClient)
+    }
+    
+    func oneTimeCodeWithOldSDKRefresh(newSDKClientId: String, completion: @escaping HTTPResultHandler<String>) {
+        api.oldSDKCodeExchange(with: httpClient, clientId: newSDKClientId, oldSDKAccessToken: legacyTokens.accessToken) { (requestResult: Result<SchibstedAccountAPIResponse<CodeExchangeResponse>, HTTPError>) in
+            switch requestResult {
+            case .failure(.errorResponse(let code, let body)):
+                // 401 might indicate expired access token
+                if code == 401 , let refreshToken = self.legacyTokens.refreshToken {
+                    self.oldSDKRefresh(refreshToken: refreshToken) { result in
+                        switch result {
+                        case .success(let newToken): // retry the request with fresh tokens
+                            self.oneTimeCode(newSDKClientId: newSDKClientId, oldSDKAccessToken: newToken, completion: completion)
+                        case .failure(let error):
+                            SchibstedAccountLogger.instance.info("Failed to refresh legacy tokens: \(error)")
+                            completion(.failure(.unexpectedError(underlying: error)))
+                        }
+                    }
+                } else {
+                    let error = HTTPError.errorResponse(code: code, body: body)
+                    SchibstedAccountLogger.instance.info("Failed legacy code exchange: \(error)")
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                SchibstedAccountLogger.instance.info("Failed legacy code exchange: \(error)")
+                completion(.failure(error))
+            case .success( let response):
+                let code = response.data.code
+                completion(.success(code))
+            }
+        }
+    }
+    
+    func oldSDKRefresh(refreshToken: String, completion: @escaping (Result<String, Error>)-> Void) {
+        
+        let resultHandler: HTTPResultHandler<TokenResponse> = { result in
+            switch result {
+            case .success(let tokenResponse):
+                completion(.success(tokenResponse.access_token))
+            case .failure(let error):
+                SchibstedAccountLogger.instance.info("Failed to migrate tokens. With error: \(error.localizedDescription)")
+                completion(.failure(error))
+            }
+        }
+        
+        api.oldSDKRefresh(with: httpClient, refreshToken: refreshToken, clientId: clientId, clientSecret: clientSecret, completion: resultHandler)
+    }
+    
+    func oneTimeCode(newSDKClientId: String, oldSDKAccessToken: String,  completion: @escaping HTTPResultHandler<String>) {
+        self.api.oldSDKCodeExchange(with: self.httpClient, clientId: newSDKClientId, oldSDKAccessToken: oldSDKAccessToken) { (requestResult: Result<SchibstedAccountAPIResponse<CodeExchangeResponse>, HTTPError>) in
+            switch requestResult {
+            case .failure( let error):
+                SchibstedAccountLogger.instance.info("Failed legacy code exchange with refreshed token: \(error)")
+                completion(.failure(error))
+            case .success( let response):
+                let code = response.data.code
+                completion(.success(code))
+            }
+        }
+    }
+}

--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
@@ -4,16 +4,19 @@ class MigratingKeychainCompatStorage: SessionStorage {
     private let newStorage: KeychainSessionStorage
     private let legacyStorage: LegacyKeychainSessionStorage
     private let legacyClient: Client
+    private let legacyClientSecret: String
     private let makeTokenRequest: (_ authCode: String, _ authState: AuthState?, _ completion:  @escaping (Result<TokenResult, TokenError>) -> Void) -> Void
     
     init(from: LegacyKeychainSessionStorage,
          to: KeychainSessionStorage,
          legacyClient: Client,
+         legacyClientSecret: String,
          makeTokenRequest: @escaping (_ authCode: String, _ authState: AuthState?, _ completion:  @escaping (Result<TokenResult, TokenError>) -> Void) -> Void)
     {
         self.newStorage = to
         self.legacyStorage = from
         self.legacyClient = legacyClient
+        self.legacyClientSecret = legacyClientSecret
         self.makeTokenRequest = makeTokenRequest
     }
     


### PR DESCRIPTION
This PR contains the logic for exchanging tokens from the Schibsteds [old login SDK](https://github.com/schibsted/account-sdk-ios) to the new login SDK.

This strategy needs to be used by brands that upgrade from the old SDK to the new SDK. Also explained [here](https://docs.google.com/document/d/1jnrAZOO4Yb1vtEymC-V0v_0pKuAqTMQ3hek_S3sORxc/edit#heading=h.8kg6jv30mysm)