### PR TITLE
1078 LegacyClientSecret support in Client and MigratingKeychainCompatStorage

### DIFF
--- a/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
+++ b/Projects/AccountSDKIOSWeb/Tests/AccountSDKIOSWebTests/Storage/Compat/MigratingKeychainCompatStorageTests.swift
@@ -15,6 +15,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage,
                                                               to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.store(userSession)
 
@@ -34,6 +35,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage,
                                                               to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.getAll()
 
@@ -52,6 +54,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         migratingStorage.remove(forClientId: clientId)
 
@@ -75,6 +78,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
         
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in
@@ -105,6 +109,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in
@@ -133,6 +138,7 @@ final class MigratingKeychainCompatStorageTests: XCTestCase {
 
         let migratingStorage = MigratingKeychainCompatStorage(from: legacyStorage, to: newStorage,
                                                               legacyClient: Client(configuration: Fixtures.clientConfig),
+                                                              legacyClientSecret: "",
                                                               makeTokenRequest: { _, _, _ in  })
         
         migratingStorage.get(forClientId: clientId) { retrievedUserSession in

--- a/Sources/AccountSDKIOSWeb/Client/Client.swift
+++ b/Sources/AccountSDKIOSWeb/Client/Client.swift
@@ -5,13 +5,15 @@ public typealias LoginResultHandler = (Result<User, LoginError>) -> Void
 
 public struct SessionStorageConfig {
     let legacyClientId: String
+    let legacyClientSecret: String
     let accessGroup: String?
     let legacyAccessGroup: String?
     
-    public init(legacyClientID: String, accessGroup: String? = nil, legacyAccessGroup: String? = nil) {
+    public init(legacyClientID: String, legacyClientSecret: String, accessGroup: String? = nil, legacyAccessGroup: String? = nil) {
         self.legacyClientId = legacyClientID
         self.accessGroup = accessGroup
         self.legacyAccessGroup = legacyAccessGroup
+        self.legacyClientSecret = legacyClientSecret
     }
 }
 
@@ -74,6 +76,7 @@ public class Client: CustomStringConvertible {
         let sessionStorage = MigratingKeychainCompatStorage(from: legacySessionStorage,
                                                             to: newSessionStorage,
                                                             legacyClient: legacyClient,
+                                                            legacyClientSecret: sessionStorageConfig.legacyClientSecret,
                                                             makeTokenRequest: { authCode, authState, completion in tokenHandler.makeTokenRequest(authCode: authCode, authState: authState, completion: completion)})
         
         self.init(configuration: configuration,

--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/Compat/MigratingKeychainCompatStorage.swift
@@ -4,16 +4,19 @@ class MigratingKeychainCompatStorage: SessionStorage {
     private let newStorage: KeychainSessionStorage
     private let legacyStorage: LegacyKeychainSessionStorage
     private let legacyClient: Client
+    private let legacyClientSecret: String
     private let makeTokenRequest: (_ authCode: String, _ authState: AuthState?, _ completion:  @escaping (Result<TokenResult, TokenError>) -> Void) -> Void
     
     init(from: LegacyKeychainSessionStorage,
          to: KeychainSessionStorage,
          legacyClient: Client,
+         legacyClientSecret: String,
          makeTokenRequest: @escaping (_ authCode: String, _ authState: AuthState?, _ completion:  @escaping (Result<TokenResult, TokenError>) -> Void) -> Void)
     {
         self.newStorage = to
         self.legacyStorage = from
         self.legacyClient = legacyClient
+        self.legacyClientSecret = legacyClientSecret
         self.makeTokenRequest = makeTokenRequest
     }
     


### PR DESCRIPTION
The legacyClientSecret is used in the old SDK to log users in. 
On upgrading from old to new SDK there are use-cases where old SDK endpoints need to be called using the clientSecret