### PR TITLE
Call completion on noData case for keychain.getValue

### DIFF
--- a/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/KeychainSessionStorage.swift
+++ b/Sources/AccountSDKIOSWeb/Lib/Storage/Keychain/KeychainSessionStorage.swift
@@ -28,6 +28,8 @@ internal class KeychainSessionStorage: SessionStorage {
             if let data = try keychain.getValue(forAccount: forClientId) {
                 let tokenData = try JSONDecoder().decode(UserSession.self, from: data)
                 completion(tokenData)
+            } else {
+                completion(nil)
             }
         } catch {
             SchibstedAccountLogger.instance.error("\(error.localizedDescription)")


### PR DESCRIPTION
On Keychain.getValue. When not finding data, the completion was not called. 
This led to a bug in upgrade strategy from old SDK to new SDK